### PR TITLE
initial commit for cloudwatch-alarms code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # terraform-aws-template
 
 [![Lint Status](https://github.com/tothenew/terraform-aws-template/workflows/Lint/badge.svg)](https://github.com/tothenew/terraform-aws-template/actions)
@@ -13,6 +14,7 @@ The following content needed to be created and managed:
  - Example Usages
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
 | Name | Version |
@@ -25,13 +27,25 @@ No providers.
 
 ## Modules
 
-No modules.
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_agent"></a> [agent](#module\_agent) | ./module/ec2-cw-agent/ | n/a |
+| <a name="module_ec2-CloudWatch-cpu"></a> [ec2-CloudWatch-cpu](#module\_ec2-CloudWatch-cpu) | ./module/ec2-cw/cpu | n/a |
+| <a name="module_ec2-CloudWatch-disk"></a> [ec2-CloudWatch-disk](#module\_ec2-CloudWatch-disk) | ./module/ec2-cw/disk | n/a |
+| <a name="module_ec2-CloudWatch-memory"></a> [ec2-CloudWatch-memory](#module\_ec2-CloudWatch-memory) | ./module/ec2-cw/memory | n/a |
+| <a name="module_ec2-CloudWatch-status"></a> [ec2-CloudWatch-status](#module\_ec2-CloudWatch-status) | ./module/ec2-cw/status | n/a |
+| <a name="module_lb_request"></a> [lb\_request](#module\_lb\_request) | ./module/load-balancer/requestCount/ | n/a |
+| <a name="module_lb_target_response_time"></a> [lb\_target\_response\_time](#module\_lb\_target\_response\_time) | ./module/load-balancer/targetresponsetime/ | n/a |
+| <a name="module_unhealthyhost"></a> [unhealthyhost](#module\_unhealthyhost) | ./module/load-balancer/unhealthyHost/ | n/a |
+
 
 ## Resources
 
 No resources.
 
 ## Inputs
+
 
 No inputs.
 
@@ -47,3 +61,15 @@ Module managed by [TO THE NEW Pvt. Ltd.](https://github.com/tothenew)
 ## License
 
 Apache 2 Licensed. See [LICENSE](https://github.com/tothenew/terraform-aws-template/blob/main/LICENSE) for full details.
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_alb_names"></a> [alb\_names](#input\_alb\_names) | n/a | `list(string)` | <pre>[<br>  "test-1"<br>]</pre> | no |
+| <a name="input_instance_id"></a> [instance\_id](#input\_instance\_id) | n/a | `list(string)` | <pre>[<br>  "i-08ef9201037dd01da"<br>]</pre> | no |
+| <a name="input_loadbalancers"></a> [loadbalancers](#input\_loadbalancers) | n/a | <pre>map(object({<br>    name         = string<br>    target_group = string<br>    az           = string<br>  }))</pre> | n/a | yes |
+| <a name="input_requests"></a> [requests](#input\_requests) | n/a | `bool` | `true` | no |
+| <a name="input_target_group_name"></a> [target\_group\_name](#input\_target\_group\_name) | n/a | `list(string)` | <pre>[<br>  "test-tg"<br>]</pre> | no |
+
+## Outputs
+
+

--- a/ec2-cw-agent/local.tf
+++ b/ec2-cw-agent/local.tf
@@ -1,0 +1,3 @@
+locals {
+    req = var.requests == true ? 1 : 0
+}

--- a/ec2-cw-agent/main.tf
+++ b/ec2-cw-agent/main.tf
@@ -1,0 +1,44 @@
+resource "aws_ssm_document" "install_cloudwatch_agent" {
+  count         = local.req
+  name          = "install-cloudwatch-agent"
+  document_type = "Command"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check and install CloudWatch Agent if not present.",
+    "parameters": {},
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": [
+              "if ! [ -x \"$(command -v amazon-cloudwatch-agent-ctl)\" ]; then",
+              "  echo 'CloudWatch agent is not installed. Installing now...'",
+              "  wget https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm",
+              "  sudo rpm -U ./amazon-cloudwatch-agent.rpm",
+              "  amazon-cloudwatch-agent-ctl -a start",
+              "else",
+              "  echo 'CloudWatch agent is already installed.'",
+              "fi"
+            ]
+          }
+        ]
+      }
+    }
+  }
+DOC
+}
+
+resource "aws_ssm_association" "association" {
+  count       = local.req
+  name        = aws_ssm_document.install_cloudwatch_agent[count.index].name
+  # name        = aws_ssm_document.install_cloudwatch_agent.name
+  targets {
+    key    = "InstanceIds"
+    values = var.instance_id
+  }
+  depends_on  = [aws_ssm_document.install_cloudwatch_agent]
+}
+

--- a/ec2-cw-agent/output.tf
+++ b/ec2-cw-agent/output.tf
@@ -1,0 +1,4 @@
+output "agent_check_result" {
+  description = "ID of the AWS SSM Association for the agent check."
+  value       = aws_ssm_association.association[*].id
+}

--- a/ec2-cw-agent/var.tf
+++ b/ec2-cw-agent/var.tf
@@ -1,0 +1,9 @@
+variable instance_id {
+  type      = list(string)
+  default   =  ["i-08ad539b968e57b66"]
+}
+
+variable requests  {
+    type    =  bool
+    default =  false
+}

--- a/ec2-cw/cpu/main.tf
+++ b/ec2-cw/cpu/main.tf
@@ -1,0 +1,16 @@
+resource "aws_cloudwatch_metric_alarm" "ec2_cpu" {
+     count                     = length(var.instance_id)
+     alarm_name                = "instance-${var.instance_id[count.index]}-cpu-utilization"
+     comparison_operator       = "GreaterThanOrEqualToThreshold"
+     evaluation_periods        = "2"
+     metric_name               = "CPUUtilization"
+     namespace                 = "AWS/EC2"
+     period                    = "120" #seconds
+     statistic                 = "Average"
+     threshold                 = "80"
+     alarm_description         = "This metric monitors ec2 cpu utilization"
+     insufficient_data_actions = []
+     dimensions = {
+       InstanceId = var.instance_id[count.index]
+     }
+}

--- a/ec2-cw/cpu/var.tf
+++ b/ec2-cw/cpu/var.tf
@@ -1,0 +1,4 @@
+variable instance_id {
+  type      = list(string)
+  default   =  ["i-08ad539b968e57b66"]
+}

--- a/ec2-cw/disk/main.tf
+++ b/ec2-cw/disk/main.tf
@@ -1,0 +1,28 @@
+data "aws_instance" "selected" {
+  for_each = toset(var.instance_id)
+  instance_id = each.value
+}
+
+resource "aws_cloudwatch_metric_alarm" "disk_alarm_1" {
+  for_each            = data.aws_instance.selected
+  alarm_name          = "DiskUtilizationAlarm-test"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "disk_used_percent"
+  namespace           = "CWAgent"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "80"
+  alarm_description  = "Disk space utilization is above 80%"
+  # alarm_actions      = [aws_sns_topic.SRE_CloudWatch_to_OpsGenie_biovitals-staging-us-west-1.arn]
+    dimensions = {
+       ImageId          = "ami-03d294e37a4820c21"
+       InstanceId       = each.key
+       Path             = "/"
+       InstanceType     = "t2.micro"
+       device           = "xvda1"
+       fstype           = "xfs"
+     }
+}
+
+

--- a/ec2-cw/disk/var.tf
+++ b/ec2-cw/disk/var.tf
@@ -1,0 +1,4 @@
+variable instance_id {
+  type      = list(string)
+  default   =  ["i-08ad539b968e57b66"]
+}

--- a/ec2-cw/main.tf
+++ b/ec2-cw/main.tf
@@ -1,0 +1,16 @@
+resource "aws_cloudwatch_metric_alarm" "ec2_cpu" {
+     count                     = length(var.instance_id)
+     alarm_name                = "instance-${var.instance_id[count.index]}-cpu-utilization"
+     comparison_operator       = "GreaterThanOrEqualToThreshold"
+     evaluation_periods        = "2"
+     metric_name               = "disk_used_percent"
+     namespace                 = "CWAgent"
+     period                    = "120" #seconds
+     statistic                 = "Average"
+     threshold                 = "80"
+     alarm_description         = "This metric monitors ec2 cpu utilization"
+     insufficient_data_actions = []
+     dimensions = {
+       InstanceId = var.instance_id[count.index]
+     }
+}

--- a/ec2-cw/memory/main.tf
+++ b/ec2-cw/memory/main.tf
@@ -1,0 +1,21 @@
+data "aws_instance" "selected" {
+  for_each = toset(var.instance_id)
+  instance_id = each.value
+}
+
+resource "aws_cloudwatch_metric_alarm" "ec2_memory" {
+     for_each                  = data.aws_instance.selected
+     alarm_name                = "instance-${each.value.id}-memory-utilization"
+     comparison_operator       = "GreaterThanOrEqualToThreshold"
+     evaluation_periods        = "2"
+     metric_name               = "mem_used_percent"
+     namespace                 = "CWAgent"
+     period                    = "120" #seconds
+     statistic                 = "Average"
+     threshold                 = "80"
+     alarm_description         = "This metric monitors ec2 cpu utilization"
+     insufficient_data_actions = []
+     dimensions = {
+       InstanceId = each.value.id
+     }
+}

--- a/ec2-cw/memory/var.tf
+++ b/ec2-cw/memory/var.tf
@@ -1,0 +1,4 @@
+variable instance_id {
+  type      = list(string)
+  default   =  ["i-08ad539b968e57b66"]
+}

--- a/ec2-cw/status/main.tf
+++ b/ec2-cw/status/main.tf
@@ -1,0 +1,21 @@
+data "aws_instance" "selected" {
+  for_each = toset(var.instance_id)
+  instance_id = each.value
+}
+
+resource "aws_cloudwatch_metric_alarm" "disk_alarm" {
+     for_each                  = data.aws_instance.selected
+     alarm_name                = "instance-${each.value.id}-status-check"
+     comparison_operator       = "GreaterThanOrEqualToThreshold"
+     evaluation_periods        = "5"
+     metric_name               = "StatusCheckFailed"
+     namespace                 = "AWS/EC2"
+     period                    = "120" #seconds
+     statistic                 = "Average"
+     threshold                 = "1"
+     alarm_description         = "This metric monitors ec2 cpu utilization"
+     insufficient_data_actions = []
+     dimensions = {
+       InstanceId       = each.value.id
+     }
+}

--- a/ec2-cw/status/var.tf
+++ b/ec2-cw/status/var.tf
@@ -1,0 +1,4 @@
+variable instance_id {
+  type      = list(string)
+  default   =  ["i-08ad539b968e57b66"]
+}

--- a/ec2-cw/var.tf
+++ b/ec2-cw/var.tf
@@ -1,0 +1,4 @@
+variable instance_id {
+  type      = list(string)
+  default   =  ["i-08ad539b968e57b66"]
+}

--- a/examples/var.tfvars
+++ b/examples/var.tfvars
@@ -1,0 +1,9 @@
+instance_id = ["i-08ef9201037dd01da"]
+requests    = false
+loadbalancers = {
+  "test-1" = {
+    name         = "test-1"
+    target_group = "test-tg"
+    az           = "ap-south-1b"
+  }
+}

--- a/loacals.tf
+++ b/loacals.tf
@@ -1,0 +1,3 @@
+locals {
+    req = var.requests == true ? 1 : 0
+}

--- a/load-balancer/requestCount/main.tf
+++ b/load-balancer/requestCount/main.tf
@@ -1,0 +1,34 @@
+data "aws_lb" "existing_loadbalancer" {
+  for_each = var.loadbalancers
+  name = each.value.name
+}
+
+data "aws_alb_target_group" "existing_tg" {
+  for_each = var.loadbalancers
+  name = each.value.target_group
+}
+
+resource "aws_cloudwatch_metric_alarm" "loadbalancer" {
+    for_each                  = var.loadbalancers
+    actions_enabled           = true
+    alarm_actions             = []
+    alarm_name                = "loadbalancer-${each.value["name"]}-RequestCount"
+    comparison_operator       = "GreaterThanOrEqualToThreshold"
+    datapoints_to_alarm       = 1
+    dimensions                = {
+        "LoadBalancer"        = data.aws_lb.existing_loadbalancer[each.key].arn_suffix
+        "TargetGroup"         = data.aws_alb_target_group.existing_tg[each.key].arn_suffix
+        "AvailabilityZone"    = each.value.az
+    }
+    evaluation_periods        = 1
+    insufficient_data_actions = []
+    metric_name               = "RequestCount"
+    namespace                 = "AWS/ApplicationELB"
+    ok_actions                = []
+    period                    = 60
+    statistic                 = "Sum"
+    tags                      = {}
+    tags_all                  = {}
+    threshold                 = 70
+    treat_missing_data        = "missing"
+}

--- a/load-balancer/requestCount/var.tf
+++ b/load-balancer/requestCount/var.tf
@@ -1,0 +1,7 @@
+variable "loadbalancers" {
+  type    = map(object({
+    name         = string
+    target_group = string
+    az           = string
+  }))
+}

--- a/load-balancer/targetresponsetime/main.tf
+++ b/load-balancer/targetresponsetime/main.tf
@@ -1,0 +1,34 @@
+data "aws_lb" "existing_loadbalancer" {
+  for_each = var.loadbalancers
+  name = each.value.name
+}
+
+data "aws_alb_target_group" "existing_tg" {
+  for_each = var.loadbalancers
+  name = each.value.target_group
+}
+
+resource "aws_cloudwatch_metric_alarm" "loadbalancer" {
+    for_each                  = var.loadbalancers
+    actions_enabled           = true
+    alarm_actions             = []
+    alarm_name                = "loadbalancer-${each.value["name"]}-Target_Response_Time"
+    comparison_operator       = "GreaterThanOrEqualToThreshold"
+    datapoints_to_alarm       = 1
+    dimensions                = {
+        "LoadBalancer"        = data.aws_lb.existing_loadbalancer[each.key].arn_suffix
+        "TargetGroup"         = data.aws_alb_target_group.existing_tg[each.key].arn_suffix
+        "AvailabilityZone"    = each.value.az
+    }
+    evaluation_periods        = 1
+    insufficient_data_actions = []
+    metric_name               = "TargetResponseTime"
+    namespace                 = "AWS/ApplicationELB"
+    ok_actions                = []
+    period                    = 60
+    statistic                 = "Sum"
+    tags                      = {}
+    tags_all                  = {}
+    threshold                 = 70
+    treat_missing_data        = "missing"
+}

--- a/load-balancer/targetresponsetime/var.tf
+++ b/load-balancer/targetresponsetime/var.tf
@@ -1,0 +1,7 @@
+variable "loadbalancers" {
+  type    = map(object({
+    name         = string
+    target_group = string
+    az           = string
+  }))
+}

--- a/load-balancer/unhealthyHost/main.tf
+++ b/load-balancer/unhealthyHost/main.tf
@@ -1,0 +1,34 @@
+data "aws_lb" "existing_loadbalancer" {
+  for_each = var.loadbalancers
+  name = each.value.name
+}
+
+data "aws_alb_target_group" "existing_tg" {
+  for_each = var.loadbalancers
+  name = each.value.target_group
+}
+
+resource "aws_cloudwatch_metric_alarm" "loadbalancer" {
+    for_each                  = var.loadbalancers
+    actions_enabled           = true
+    alarm_actions             = []
+    alarm_name                = "loadbalancer-${each.value["name"]}-UnhealthyHostCount"
+    comparison_operator       = "GreaterThanThreshold"
+    datapoints_to_alarm       = 1
+    dimensions                = {
+        "LoadBalancer"        = data.aws_lb.existing_loadbalancer[each.key].arn_suffix
+        "TargetGroup"         = data.aws_alb_target_group.existing_tg[each.key].arn_suffix
+        "AvailabilityZone"    = each.value.az
+    }
+    evaluation_periods        = 1
+    insufficient_data_actions = []
+    metric_name               = "UnHealthyHostCount"
+    namespace                 = "AWS/ApplicationELB"
+    ok_actions                = []
+    period                    = 60
+    statistic                 = "Sum"
+    tags                      = {}
+    tags_all                  = {}
+    threshold                 = 0
+    treat_missing_data        = "missing"
+}

--- a/load-balancer/unhealthyHost/var.tf
+++ b/load-balancer/unhealthyHost/var.tf
@@ -1,0 +1,7 @@
+variable "loadbalancers" {
+  type    = map(object({
+    name         = string
+    target_group = string
+    az           = string
+  }))
+}

--- a/main.tf
+++ b/main.tf
@@ -1,41 +1,41 @@
 module agent {
-    source      =   "./module/ec2-cw-agent/"
+    source      =   "./ec2-cw-agent/"
     instance_id =   var.instance_id
     requests    =   var.requests
 }
 
 module ec2-CloudWatch-cpu   {
-    source  =   "./module/ec2-cw/cpu"
+    source  =   "./ec2-cw/cpu"
     instance_id =   var.instance_id
 }
 
 module ec2-CloudWatch-disk   {
-    source  =   "./module/ec2-cw/disk"
+    source  =   "./ec2-cw/disk"
     instance_id =   var.instance_id
 }
 
 module ec2-CloudWatch-status   {
-    source  =   "./module/ec2-cw/status"
+    source  =   "./ec2-cw/status"
     instance_id =   var.instance_id
 }
 
 module ec2-CloudWatch-memory   {
-    source  =   "./module/ec2-cw/memory"
+    source  =   "./ec2-cw/memory"
     instance_id =   var.instance_id
 }
 
 module lb_request {
-    source        =   "./module/load-balancer/requestCount/"
+    source        =   "./load-balancer/requestCount/"
     loadbalancers = var.loadbalancers
 }
 
 module lb_target_response_time {
-    source        =   "./module/load-balancer/targetresponsetime/"
+    source        =   "./load-balancer/targetresponsetime/"
     loadbalancers = var.loadbalancers
 }
 
 module unhealthyhost {
-    source        =   "./module/load-balancer/unhealthyHost/"
+    source        =   "./load-balancer/unhealthyHost/"
     loadbalancers = var.loadbalancers
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,42 @@
+module agent {
+    source      =   "./module/ec2-cw-agent/"
+    instance_id =   var.instance_id
+    requests    =   var.requests
+}
+
+module ec2-CloudWatch-cpu   {
+    source  =   "./module/ec2-cw/cpu"
+    instance_id =   var.instance_id
+}
+
+module ec2-CloudWatch-disk   {
+    source  =   "./module/ec2-cw/disk"
+    instance_id =   var.instance_id
+}
+
+module ec2-CloudWatch-status   {
+    source  =   "./module/ec2-cw/status"
+    instance_id =   var.instance_id
+}
+
+module ec2-CloudWatch-memory   {
+    source  =   "./module/ec2-cw/memory"
+    instance_id =   var.instance_id
+}
+
+module lb_request {
+    source        =   "./module/load-balancer/requestCount/"
+    loadbalancers = var.loadbalancers
+}
+
+module lb_target_response_time {
+    source        =   "./module/load-balancer/targetresponsetime/"
+    loadbalancers = var.loadbalancers
+}
+
+module unhealthyhost {
+    source        =   "./module/load-balancer/unhealthyHost/"
+    loadbalancers = var.loadbalancers
+}
+
+

--- a/var.tf
+++ b/var.tf
@@ -1,0 +1,27 @@
+variable instance_id {
+  type    = list(string)
+  default = ["i-08ef9201037dd01da"]
+}
+
+variable requests  {
+    type    =  bool
+    default =  true
+}
+
+variable "alb_names" {
+  type    = list(string)
+  default = ["test-1"]  # Replace with the names of your ALBs
+}
+
+variable "target_group_name" {
+  type    = list(string)
+  default = ["test-tg"]  # Replace with the names of your ALBs
+}
+
+variable "loadbalancers" {
+  type    = map(object({
+    name         = string
+    target_group = string
+    az           = string
+  }))
+}


### PR DESCRIPTION
This PR introduces the Terraform modules for AWS Cloudwatch Alarms
Key Changes:

  - Introduced a module for installing the AWS Cloudwatch agent after checking whether the instance has an agent or not.
  - Added module for EC2 Instances Disk,CPU,Memory,Status check alarms.
  - Added module for Load Balancer
  - Modules for RDS WIP